### PR TITLE
Import userTrackingPlugins to track player events again

### DIFF
--- a/.changeset/sharp-aliens-decide.md
+++ b/.changeset/sharp-aliens-decide.md
@@ -1,0 +1,5 @@
+---
+'@asicupv/opencast-engage-paella-player': patch
+---
+
+Import userTrackingPlugins to track player events again

--- a/packages/opencast-engage-paella-player/src/watch.ts
+++ b/packages/opencast-engage-paella-player/src/watch.ts
@@ -16,6 +16,7 @@ import { webglPlugins } from '@asicupv/paella-webgl-plugins';
 import { videoPlugins } from '@asicupv/paella-video-plugins';
 import { extraPlugins } from '@asicupv/paella-extra-plugins';
 import { opencastPlugins } from '@asicupv/paella-opencast-plugins';
+import { userTrackingPlugins } from '@asicupv/paella-user-tracking';
 
 // const { opencastPlugins } = await import('@asicupv/paella-opencast-plugins');
 
@@ -67,6 +68,7 @@ window.addEventListener('load', async () => {
             ...webglPlugins,
             ...extraPlugins,
             ...opencastPlugins,
+            ...userTrackingPlugins,
         ],
         opencast: {
             presentationUrl: OC_PRESENTATION_URL,


### PR DESCRIPTION
Fixes part of #158.
Player events were no longer tracked for tools like Matomo. With the import of the `userTrackingPlugins` player event tracking is working again.